### PR TITLE
chore: rm outdated daocloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 
 2. 安装 Docker 
 
-    国内用户使用脚本一键安装: `sudo curl -sSL https://get.daocloud.io/docker | sh`  
-    国外用户使用脚本一键安装: `sudo curl -sSL get.docker.com | sh`
+    - 国内用户可参照 [MirrorZ](https://mirrors.cernet.edu.cn/) 的教程通过镜像安装：[https://help.mirrors.cernet.edu.cn/docker-ce/](https://help.mirrors.cernet.edu.cn/docker-ce/)    
+    - 国外用户使用脚本一键安装: `sudo curl -sSL get.docker.com | sh`
     
     详细步骤参照： [https://docs.docker.com/install/](https://docs.docker.com/install/)
 


### PR DESCRIPTION
在校内部署的时候发现，这玩意儿好像已经完全坏了（

```bash
$ curl -sSL https://get.daocloud.io/docker
<html>
<head><title>503 Service Temporarily Unavailable</title></head>
<body>
<center><h1>503 Service Temporarily Unavailable</h1></center>
</body>
</html>
```