### PR TITLE
refactor: move sensitive config to .env file for improved security an…

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,9 @@
+# Online Judge Tokens
+# Remember to change these values to secure tokens
+TOKEN=CHANGE_THIS
+JUDGE_SERVER_TOKEN=CHANGE_THIS
+
+# PostgreSQL Configuration
+POSTGRES_DB=onlinejudge
+POSTGRES_USER=onlinejudge
+POSTGRES_PASSWORD=onlinejudge

--- a/README.en.md
+++ b/README.en.md
@@ -27,7 +27,19 @@
     git clone -b 2.0 https://github.com/QingdaoU/OnlineJudgeDeploy.git && cd OnlineJudgeDeploy
     ```
 
-2. Start service
+2. Configure environment variables
+
+    The system uses an `.env` file to store sensitive configuration information. Please edit this file to set secure token values and database credentials:
+    
+    ```bash
+    # Edit the .env file
+    vim .env
+    
+    # Change the values of TOKEN and JUDGE_SERVER_TOKEN from CHANGE_THIS to your own secure tokens
+    # Modify PostgreSQL database configuration (POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD) as needed
+    ```
+
+3. Start service
 
     ```bash
     docker-compose up -d

--- a/README.md
+++ b/README.md
@@ -40,7 +40,19 @@ Windows 下的安装仅供体验，勿在生产环境使用。如有必要，请
     git clone -b 2.0 https://github.com/QingdaoU/OnlineJudgeDeploy.git && cd OnlineJudgeDeploy
     ```
 
-2. 启动服务
+2. 配置环境变量
+
+    系统使用了 `.env` 文件来存储敏感配置信息。请编辑此文件设置安全的令牌值和数据库凭据：
+    
+    ```bash
+    # 编辑 .env 文件
+    vim .env
+    
+    # 将 TOKEN 和 JUDGE_SERVER_TOKEN 的值从 CHANGE_THIS 修改为您自己的安全令牌
+    # 根据需要修改 PostgreSQL 数据库的配置（POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD）
+    ```
+
+3. 启动服务
 
     ```bash
     docker-compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,9 @@ services:
     volumes:
       - ./data/postgres:/var/lib/postgresql/data
     environment:
-      - POSTGRES_DB=onlinejudge
-      - POSTGRES_USER=onlinejudge
-      - POSTGRES_PASSWORD=onlinejudge
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
 
   oj-judge:
     image: registry.cn-hongkong.aliyuncs.com/oj-image/judge:1.6.1
@@ -37,7 +37,7 @@ services:
     environment:
       - SERVICE_URL=http://oj-judge:8080
       - BACKEND_URL=http://oj-backend:8000/api/judge_server_heartbeat/
-      - TOKEN=CHANGE_THIS
+      - TOKEN=${TOKEN}
       # - judger_debug=1
 
   oj-backend:
@@ -50,10 +50,10 @@ services:
     volumes:
       - ./data/backend:/data
     environment:
-      - POSTGRES_DB=onlinejudge
-      - POSTGRES_USER=onlinejudge
-      - POSTGRES_PASSWORD=onlinejudge
-      - JUDGE_SERVER_TOKEN=CHANGE_THIS
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - JUDGE_SERVER_TOKEN=${JUDGE_SERVER_TOKEN}
       # - FORCE_HTTPS=1
       # - STATIC_CDN_HOST=cdn.oj.com
     ports:


### PR DESCRIPTION
> [!IMPORTANT]
> 这次更新不会影响现有功能，仅改进了配置方式，使系统更加安全、易用和可维护。

# 将配置参数移至 .env 文件

本次更新将 docker-compose.yml 中的重要配置参数移至单独的 .env 文件，主要包括：
- 将安全令牌 (TOKEN 和 JUDGE_SERVER_TOKEN) 统一放置在 .env 文件
- 将数据库凭据 (POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD) 集中管理

## 优势
1. 提高安全性：用户可以一目了然地看到哪些参数需要被修改，避免因未修改默认值而带来的安全隐患
2. 简化配置：用户不需要细读 docker-compose.yml 文件内容，只需要关注 .env 文件即可
3. 便于维护：当需要部署多台评测服务器时，只需管理 .env 文件而无需修改每个 docker-compose.yml
4. 遵循最佳实践：将敏感信息与配置代码分离，符合容器化应用的最佳实践

## 使用方法
用户只需编辑 .env 文件，设置自定义的安全令牌和数据库凭据，然后运行 docker-compose 即可。README 文件中已添加相关说明，使其更加直观清晰。